### PR TITLE
Generate squashfs stage 2 artifacts for faster assembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ build-inner:
 	@rm -rf $(FINAL_ARTIFACTS_DIR)
 	@mkdir -p $(FINAL_ARTIFACTS_DIR)
 	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/ovmf.tdx.fd $(FINAL_ARTIFACTS_DIR)
-	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/oasis-vm-stage2-basic-tdx.tar.bz2 $(FINAL_ARTIFACTS_DIR)/stage2-basic.tar.bz2
-	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/oasis-vm-stage2-podman-tdx.tar.bz2 $(FINAL_ARTIFACTS_DIR)/stage2-podman.tar.bz2
+	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/oasis-vm-stage2-basic-tdx.squashfs $(FINAL_ARTIFACTS_DIR)/stage2-basic.squashfs
+	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/oasis-vm-stage2-podman-tdx.squashfs $(FINAL_ARTIFACTS_DIR)/stage2-podman.squashfs
 	@cp $(INTERMEDIATE_ARTIFACTS_DIR)/bzImage-initramfs-tdx.bin $(FINAL_ARTIFACTS_DIR)/stage1.bin
 
 # Cleanup.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ will switch the root filesystem to Stage 2 and execute `/init`.
 
 ### `oasis-vm-stage2-basic`
 
-Builds the basic Stage 2 _template_ which is a `tar.bz2` archive containing a
+Builds the basic Stage 2 _template_ which is a squash filesystem containing a
 minimal root filesystem that can be used as Stage 2 for a trivial Oasis runtime.
 
 See below for information on using these templates.
 
 ### `oasis-vm-stage2-podman`
 
-Builds the basic Stage 2 _template_ which is a `tar.bz2` archive containing a
+Builds the basic Stage 2 _template_ which is a squash filesystem containing a
 minimal root filesystem that can be used as Stage 2 for a Podman container
 based system.
 

--- a/meta-oasis-vm/recipes-core/images/common.inc
+++ b/meta-oasis-vm/recipes-core/images/common.inc
@@ -6,7 +6,7 @@ IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES = "squashfs"
 
 inherit core-image
 


### PR DESCRIPTION
Using squashfs images directly makes it very fast to append to them for final assembly without decompression.